### PR TITLE
Use builtin complex instead of now-deprecated numpy implementation

### DIFF
--- a/src/svg2omap.py
+++ b/src/svg2omap.py
@@ -285,7 +285,7 @@ class Converter(object):
         # Determine center coord
         cx = xmin+(width_px/2)
         cy = ymin+(height_px/2)
-        pt_cen = np.complex(cx, cy)
+        pt_cen = complex(cx, cy)
 
         features = []
         i = 0


### PR DESCRIPTION
I had a use for this code and it stands up pretty well given it has not been touched for 3 years!
Thank you.

To make it run with a simple square svg I had to update to use the Python builtin complex instead of numpy.
numpy deprecated complex when it was added to Python causing an error to be raised.

This fixes that.